### PR TITLE
Optimize identity fetching

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bsv/identity-react",
-  "version": "1.1.12",
+  "version": "1.1.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@bsv/identity-react",
-      "version": "1.1.12",
+      "version": "1.1.13",
       "license": "Open BSV License",
       "dependencies": {
         "@bsv/sdk": "^2.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.1.13",
       "license": "Open BSV License",
       "dependencies": {
-        "@bsv/sdk": "^2.0.0",
+        "@bsv/sdk": "^2.0.3",
         "@bsv/uhrp-react": "^1.0.5",
         "@types/jest": "^29.5.11",
         "@types/node": "^20.11.0",
@@ -184,9 +184,9 @@
       }
     },
     "node_modules/@bsv/sdk": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@bsv/sdk/-/sdk-2.0.0.tgz",
-      "integrity": "sha512-W6CoAFRnYAetr8d90odwjdvIAgtV6CVUWeH5OhBwUrdDsHA8GAlv492VMwcQ+Eh46GfuXrnPvvW+fE25fMswNg==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@bsv/sdk/-/sdk-2.0.3.tgz",
+      "integrity": "sha512-HvZrGE5kj433sZDQVpK9UDMvCsrza6PVrguCJVtR/KYYyAE7+RcFRTXuCROnDz7ZNKotA335uKuph2p5iSv5og==",
       "license": "SEE LICENSE IN LICENSE.txt"
     },
     "node_modules/@bsv/uhrp-react": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bsv/identity-react",
-  "version": "1.1.12",
+  "version": "1.1.13",
   "description": "React components for resolving identity information on the MetaNet.",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     }
   },
   "dependencies": {
-    "@bsv/sdk": "^2.0.0",
+    "@bsv/sdk": "^2.0.3",
     "@bsv/uhrp-react": "^1.0.5",
     "@types/jest": "^29.5.11",
     "@types/node": "^20.11.0",

--- a/src/components/IdentityCard.tsx
+++ b/src/components/IdentityCard.tsx
@@ -14,38 +14,39 @@ const CACHE_EXPIRY = 5 * 60 * 1000; // 5 minutes
 const MAX_CACHE_ENTRIES = 100; // Prevent unbounded growth
 
 class IdentityCache {
-  private getCache(): Map<string, { identity: DisplayableIdentity; timestamp: number }> {
+  private cache: Map<string, { identity: DisplayableIdentity; timestamp: number }>;
+
+  constructor() {
+    // Hydrate once from sessionStorage on init
+    this.cache = new Map();
     try {
       const stored = sessionStorage.getItem(CACHE_KEY);
       if (stored) {
         const parsed = JSON.parse(stored);
-        return new Map(Object.entries(parsed));
+        for (const [key, value] of Object.entries(parsed)) {
+          this.cache.set(key, value as { identity: DisplayableIdentity; timestamp: number });
+        }
       }
     } catch (e) {
       console.warn('Failed to load identity cache from sessionStorage:', e);
     }
-    return new Map();
   }
 
-  private saveCache(cache: Map<string, { identity: DisplayableIdentity; timestamp: number }>): void {
+  private persist(): void {
     try {
-      const obj = Object.fromEntries(cache);
-      sessionStorage.setItem(CACHE_KEY, JSON.stringify(obj));
+      sessionStorage.setItem(CACHE_KEY, JSON.stringify(Object.fromEntries(this.cache)));
     } catch (e) {
       console.warn('Failed to save identity cache to sessionStorage:', e);
     }
   }
 
   get(identityKey: string): DisplayableIdentity | null {
-    const cache = this.getCache();
-    const entry = cache.get(identityKey);
-
+    const entry = this.cache.get(identityKey);
     if (!entry) return null;
 
-    // Check if expired
     if (Date.now() - entry.timestamp > CACHE_EXPIRY) {
-      cache.delete(identityKey);
-      this.saveCache(cache);
+      this.cache.delete(identityKey);
+      this.persist();
       return null;
     }
 
@@ -53,25 +54,16 @@ class IdentityCache {
   }
 
   set(identityKey: string, identity: DisplayableIdentity): void {
-    const cache = this.getCache();
-
     // Simple LRU: remove oldest entries if cache is full
-    if (cache.size >= MAX_CACHE_ENTRIES) {
-      const firstKey = cache.keys().next().value;
+    if (this.cache.size >= MAX_CACHE_ENTRIES) {
+      const firstKey = this.cache.keys().next().value;
       if (firstKey) {
-        cache.delete(firstKey);
+        this.cache.delete(firstKey);
       }
     }
 
-    cache.set(identityKey, {
-      identity,
-      timestamp: Date.now()
-    });
-    this.saveCache(cache);
-  }
-
-  size(): number {
-    return this.getCache().size;
+    this.cache.set(identityKey, { identity, timestamp: Date.now() });
+    this.persist();
   }
 }
 

--- a/src/components/IdentitySearchField.tsx
+++ b/src/components/IdentitySearchField.tsx
@@ -225,11 +225,15 @@ const IdentitySearchField: React.FC<IdentitySearchFieldProps> = ({
       return []
     }
 
-    const uniqueOptions = deduplicate
-      ? identities.filter((identity, index, array) =>
-        array.findIndex(i => i.identityKey === identity.identityKey) === index
-      )
-      : identities
+    let uniqueOptions = identities
+    if (deduplicate) {
+      const seen = new Set<string>()
+      uniqueOptions = identities.filter(identity => {
+        if (seen.has(identity.identityKey)) return false
+        seen.add(identity.identityKey)
+        return true
+      })
+    }
 
     return filterOptions(uniqueOptions, { inputValue })
   }, [identities, deduplicate, filterOptions, inputValue])

--- a/src/hooks/useIdentitySearch.ts
+++ b/src/hooks/useIdentitySearch.ts
@@ -80,6 +80,7 @@ export const useIdentitySearch = ({
   // Refs for managing async operations
   const debounceTimeoutRef = useRef<NodeJS.Timeout | null>(null)
   const lastRequestIdRef = useRef<number>(0)
+  const abortControllerRef = useRef<AbortController | null>(null)
   const justSelectedRef = useRef<boolean>(false) // Prevent search after selection
   const shouldClearResultsRef = useRef<boolean>(false) // Track explicit clear actions (X button)
 
@@ -100,9 +101,16 @@ export const useIdentitySearch = ({
         return
       }
 
+      // Abort any previous in-flight request
+      if (abortControllerRef.current) {
+        abortControllerRef.current.abort()
+      }
+      const controller = new AbortController()
+      abortControllerRef.current = controller
+
       setIsLoading(true)
 
-      const searchResults = await fetchIdentities(query, wallet, options, originator)
+      const searchResults = await fetchIdentities(query, wallet, options, originator, controller.signal)
 
       // Verify this is still the latest request before updating state (prevents race conditions)
       if (requestId === lastRequestIdRef.current) {
@@ -112,10 +120,11 @@ export const useIdentitySearch = ({
         setIsLoading(false)
       }
     } catch (error: unknown) {
+      // Silently ignore aborted requests
+      if (error instanceof DOMException && error.name === 'AbortError') return
       // Only handle error if this is still the latest request
       if (requestId === lastRequestIdRef.current) {
         console.error('Identity search failed:', error)
-        console.error('Search params:', { query, wallet: !!wallet, options, originator })
         setIdentities([])
         setIsLoading(false)
       }
@@ -168,10 +177,10 @@ export const useIdentitySearch = ({
     // Show loading state immediately for non-cached searches
     setIsLoading(true)
 
-    // Debounce the search - wait 300ms after user stops typing
+    // Debounce the search - wait 400ms after user stops typing
     debounceTimeoutRef.current = setTimeout(() => {
       performSearch(inputValue.trim(), requestId)
-    }, 300)
+    }, 400)
 
     // Cleanup function
     return () => {
@@ -188,6 +197,7 @@ export const useIdentitySearch = ({
       if (debounceTimeoutRef.current) {
         clearTimeout(debounceTimeoutRef.current)
       }
+      abortControllerRef.current?.abort()
     }
   }, [])
 

--- a/src/utils/identityUtils.ts
+++ b/src/utils/identityUtils.ts
@@ -9,22 +9,52 @@ export const isIdentityKey = (key: string) => {
   return regex.test(key)
 }
 
-export const fetchIdentities = async (query: string, wallet?: WalletInterface | undefined, options?: IdentityClientOptions | undefined, originator?: OriginatorDomainNameStringUnder250Bytes | undefined) => {
-  let results
-  const client = new IdentityClient(wallet, options, originator)
-  // Figure out if the query is by IdentityKey
-  if (isIdentityKey(query)) {
-    results = await client.resolveByIdentityKey({
-      identityKey: query
-    })
-  } else {
-    results = await client.resolveByAttributes({
-      attributes: {
-        any: query,
-      }
-    })
+// Cache the IdentityClient so ContactsManager's in-memory cache persists across searches
+let cachedClient: IdentityClient | null = null
+let cachedWallet: WalletInterface | undefined
+let cachedOptionsJson: string | undefined
+let cachedOriginator: OriginatorDomainNameStringUnder250Bytes | undefined
+
+function getClient(wallet?: WalletInterface, options?: IdentityClientOptions, originator?: OriginatorDomainNameStringUnder250Bytes): IdentityClient {
+  // wallet is compared by reference — callers should pass a stable instance
+  // options is compared by value (JSON) since callers may create new object literals
+  const optionsJson = options != null ? JSON.stringify(options) : undefined
+  if (cachedClient && cachedWallet === wallet && cachedOptionsJson === optionsJson && cachedOriginator === originator) {
+    return cachedClient
   }
-  return results
+  cachedClient = new IdentityClient(wallet, options, originator)
+  cachedWallet = wallet
+  cachedOptionsJson = optionsJson
+  cachedOriginator = originator
+  return cachedClient
+}
+
+export const fetchIdentities = async (
+  query: string,
+  wallet?: WalletInterface | undefined,
+  options?: IdentityClientOptions | undefined,
+  originator?: OriginatorDomainNameStringUnder250Bytes | undefined,
+  signal?: AbortSignal
+) => {
+  // Bail immediately if already aborted
+  if (signal?.aborted) throw new DOMException('Aborted', 'AbortError')
+
+  const client = getClient(wallet, options, originator)
+
+  // Race the actual fetch against the abort signal so callers can cancel
+  // in-flight requests when a newer query supersedes this one.
+  const fetchPromise = isIdentityKey(query)
+    ? client.resolveByIdentityKey({ identityKey: query }, true)
+    : client.resolveByAttributes({ attributes: { any: query } }, true)
+
+  if (!signal) return await fetchPromise
+
+  return await Promise.race([
+    fetchPromise,
+    new Promise<never>((_, reject) => {
+      signal.addEventListener('abort', () => reject(new DOMException('Aborted', 'AbortError')), { once: true })
+    })
+  ])
 }
 
 // Returns the correct tool tip depending on the certifier and certificate type


### PR DESCRIPTION
## Description of Changes

- Reuses the same client across searches so ContactsManager's in-memory cache persists instead of being discarded on every call.
- New searches abort previous in-flight requests via AbortController + Promise.race, preventing stale queries from blocking the UI
- Debounce increased from 300ms → 400ms to reduce redundant network requests
- LRU cache optimized
- Request ID system ensures only the latest query's results are applied to state

## Testing Procedure

I have tested locally while linked to peerpay and have observed performance / UX improvements.

- [x] I have tested manually in my local environment

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have run `npm version patch` so that my changes will trigger a new version to be released when they are merged